### PR TITLE
Only keep full qimg inmemory when used

### DIFF
--- a/src/cropper/models/image.py
+++ b/src/cropper/models/image.py
@@ -1,21 +1,26 @@
+from PySide6.QtCore import Qt, QSize
 from PySide6.QtGui import QImage
 
 
 class Image:
-  def __init__(self, qimg: QImage, path: str):
-    self.qimg = qimg
+  ThumbnailSize = QSize(200, 250)
+
+  def __init__(self, data: bytes, path: str):
+    self.data: bytes = data
+    self.qimg = QImage.fromData(data)
     self.path = path
-    self.thumb = None
+    self.thumb = self.qimg.scaled(Image.ThumbnailSize, Qt.KeepAspectRatio)
     self.left = 0
-    self.right = qimg.width()
-
-  @property
-  def width(self):
-    return self.qimg.width()
-
-  @property
-  def height(self):
-    return self.qimg.height()
+    self.right = self.qimg.width() - 1
+    self.width = self.qimg.width()
+    self.height = self.qimg.height()
 
   def __repr__(self):
-    return f'{self.qimg.width()}x{self.qimg.height()} {self.left}:{self.right}'
+    return f'{self.width}x{self.height} {self.left}:{self.right}'
+
+  def load_qimg(self):
+    self.qimg = QImage.fromData(self.data)
+
+  # Remove qimg to save RAM
+  def clear(self):
+    del self.qimg

--- a/src/cropper/models/load.py
+++ b/src/cropper/models/load.py
@@ -22,8 +22,9 @@ class Load(QThread):
         img_data = arch.read(path)
         if not img_data:
           continue
-        img = Image(QImage.fromData(img_data), path)
+        img = Image(img_data, path)
         self.set_margins(img)
+        img.clear()
         self.page_ready.emit(img)
     self.finished.emit()
 

--- a/src/cropper/views/main_view.py
+++ b/src/cropper/views/main_view.py
@@ -50,8 +50,10 @@ class MainView(QMainWindow):
     for img in self.ui.pages_list_view.model().elements:
       img_dir_path = os.path.join(dir_path, os.path.dirname(img.path))
       os.makedirs(img_dir_path, exist_ok=True)
+      img.load_qimg()
       copy = img.qimg.copy(img.left, 0, img.right - img.left, img.height)
       copy.save(os.path.join(dir_path, img.path))
+      img.clear()
 
     os.chdir(dir_path) # So ZipFile works properly
     with ZipFile(file_name[0], 'w') as zip:

--- a/src/cropper/views/pages_view.py
+++ b/src/cropper/views/pages_view.py
@@ -19,20 +19,19 @@ class PageDelegate(QStyledItemDelegate):
     if not img:
       return
     rect = option.rect
-    if not img.thumb:
-      img.thumb = img.qimg.scaled(rect.width(), rect.height(), Qt.KeepAspectRatio)
+
     x = rect.x() + (rect.width() - img.thumb.width()) / 2
     y = rect.y() + (rect.height() - img.thumb.height()) / 2
     painter.drawImage(QPoint(x, y), img.thumb)
     # Draw margins
-    l = img.left * img.thumb.width() / img.qimg.width()
+    l = img.left * img.thumb.width() / img.width
     # x, y, width, height
     painter.fillRect(x, y, l, img.thumb.height(), self.margin_color)
-    r = (img.qimg.width() - img.right) * img.thumb.width() / img.qimg.width()
+    r = (img.width - img.right) * img.thumb.width() / img.width
     painter.fillRect(1 + x + img.thumb.width() - r, y, r, img.thumb.height(), self.margin_color)
 
   def sizeHint(self, option: QStyleOptionViewItem, index: Union[QModelIndex, QPersistentModelIndex]) -> QSize:
-    return QSize(200, 250)
+    return Image.ThumbnailSize
 
 
 class PagesModel(QAbstractListModel):
@@ -79,7 +78,9 @@ class PagesView(QListView):
   def open_full_view(self, index: QModelIndex):
     if not index.isValid():
       return
-    image = index.data()
+    image: Image = index.data()
     if image:
+      image.load_qimg()
       dialog = FullPageDialog(self, image)
       dialog.open()
+      image.clear()


### PR DESCRIPTION
Keeping whole pages in memory uses a lot of RAM. Instead, only load it when used and free memory right after